### PR TITLE
Snapshot assertion improvements

### DIFF
--- a/src/Bard.Tests/gRPC/__snapshots__/GRpcTests.Call_grpc_snapshot.snap
+++ b/src/Bard.Tests/gRPC/__snapshots__/GRpcTests.Call_grpc_snapshot.snap
@@ -1,0 +1,3 @@
+﻿{
+  "IsAccepted": true
+}

--- a/src/Bard.Tests/gRPC/gRPCTests.cs
+++ b/src/Bard.Tests/gRPC/gRPCTests.cs
@@ -76,6 +76,26 @@ namespace Bard.Tests.gRPC
 
             scenario.Then.Response.ShouldBe.Ok();
         }
+        
+        [Fact]
+        public void Call_grpc_snapshot()
+        {
+            var scenario = GrpcScenarioConfiguration
+                .UseGrpc<CreditRatingCheck.CreditRatingCheckClient>()
+                .Configure(options =>
+                {
+                    options.Services = _host.Services;
+                    options.LogMessage = s => _output.WriteLine(s);
+                    options.GrpcClient = c => new CreditRatingCheck.CreditRatingCheckClient(c);
+                    options.Client = _httpClient;
+                });
+
+            var creditRequest = new CreditRequest {CustomerId = "id0201", Credit = 7000};
+
+            scenario.When.Grpc(client => client.CheckCreditRequest(creditRequest));
+
+            scenario.Then.Snapshot().Match<CreditReply>();
+        }
 
         public void Dispose()
         {

--- a/src/Bard.gRPC/Internal/GrpcWhen.cs
+++ b/src/Bard.gRPC/Internal/GrpcWhen.cs
@@ -13,7 +13,7 @@ namespace Bard.gRPC.Internal
 
         internal When(Func<TGrpcClient> grpcClientFactory, EventAggregator eventAggregator, Api api,
             LogWriter logWriter, Action preApiCall) : base(
-            api, logWriter, preApiCall)
+            api, eventAggregator, logWriter, preApiCall)
         {
             _grpcClientFactory = grpcClientFactory;
             _eventAggregator = eventAggregator;

--- a/src/Bard/Configuration/ScenarioConfiguration.cs
+++ b/src/Bard/Configuration/ScenarioConfiguration.cs
@@ -20,7 +20,7 @@ namespace Bard.Configuration
 
             configure(options);
 
-            return new Scenario(options);
+            return new Scenario(options, new EventAggregator());
         }
 
         /// <summary>
@@ -58,7 +58,7 @@ namespace Bard.Configuration
 
             configure(options);
 
-            return new Scenario<TStoryBook, TStoryData>(options);
+            return new Scenario<TStoryBook, TStoryData>(options, new EventAggregator());
         }
     }
 }

--- a/src/Bard/IResponse.cs
+++ b/src/Bard/IResponse.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net;
 
 namespace Bard
@@ -19,11 +20,15 @@ namespace Bard
 
         internal bool Log { get; set; }
 
+        internal bool ExceededElapsedTime(int? milliseconds);
+        
         /// <summary>
         ///     Assert the elapsed time of the API response
         /// </summary>
         ITime Time { get; }
 
+        internal TimeSpan? ElapsedTime { get; }
+        
         internal int? MaxElapsedTime { get; set; }
 
         /// <summary>

--- a/src/Bard/Infrastructure/LogWriter.cs
+++ b/src/Bard/Infrastructure/LogWriter.cs
@@ -15,6 +15,7 @@ namespace Bard.Infrastructure
     /// </summary>
     public class LogWriter
     {
+        private const int TotalLength = 100;
         private readonly EventAggregator _eventAggregator;
         private readonly Action<string> _logMessage;
 
@@ -59,12 +60,10 @@ namespace Bard.Infrastructure
         {
             var content = AsyncHelper.RunSync(() => httpResponse.Content.ReadAsStringAsync());
             LogMessage($"Http Status Code:  {httpResponse.StatusCode.ToString()} ({(int) httpResponse.StatusCode})");
-            
+
             if (elapsedTime != null)
-            {
-                LogMessage($"Elapsed Time: {Math.Round(elapsedTime.Value.TotalMilliseconds)} (milliseconds)");    
-            }
-            
+                LogMessage($"Elapsed Time: {Math.Round(elapsedTime.Value.TotalMilliseconds)} (milliseconds)");
+
             foreach (var header in httpResponse.Content.Headers)
                 LogMessage($"{header.Key}:{string.Join(' ', header.Value)}");
 
@@ -128,10 +127,10 @@ namespace Bard.Infrastructure
 
         internal void LogHeaderMessage(string message)
         {
-            var totalLength = 100;
+            var totalLength = TotalLength;
             var messageLength = message.Length;
 
-            if (messageLength > totalLength) totalLength = messageLength + 2;
+            if (messageLength > TotalLength) totalLength = messageLength + 2;
 
             var envelopeLength = totalLength - 2;
 
@@ -147,8 +146,8 @@ namespace Bard.Infrastructure
 
             // 27 / 2 = 13.5 13 + 14
 
-            var astrixLine = new string('*', totalLength);
-            _logMessage(astrixLine);
+            LogLineBreak(totalLength);
+            
             messageBuilder.Append("*");
             messageBuilder.Append((char) 32, pre);
             messageBuilder.Append(message);
@@ -156,7 +155,18 @@ namespace Bard.Infrastructure
             messageBuilder.Append("*");
 
             _logMessage(messageBuilder.ToString());
+            LogLineBreak(totalLength);
+            BlankLine();
+        }
+
+        internal void LogLineBreak(int totalLength = TotalLength)
+        {
+            var astrixLine = new string('*', totalLength);
             _logMessage(astrixLine);
+        }
+
+        internal void BlankLine()
+        {
             _logMessage(string.Empty);
         }
     }

--- a/src/Bard/Internal/Then/BardAssert.cs
+++ b/src/Bard/Internal/Then/BardAssert.cs
@@ -22,7 +22,7 @@ namespace Bard.Internal.Then
 
             if (JToken.DeepEquals(expectedSnapshotJToken, actualSnapshotJToken))
                 return;
-
+            
             var snapShotDiff = FindDiff(JToken.Parse(expectedSnapshot), JToken.Parse(actualSnapshot));
             throw new BardSnapshotException(snapShotDiff);
         }
@@ -82,8 +82,8 @@ namespace Bard.Internal.Then
                     var actual = (JArray) actualSnapshot;
                     var plus = new JArray(expected.Except(actual, new JTokenEqualityComparer()));
                     var minus = new JArray(actual.Except(expected, new JTokenEqualityComparer()));
-                    if (plus.HasValues) diff["+"] = plus;
-                    if (minus.HasValues) diff["-"] = minus;
+                    if (plus.HasValues) diff["expected"] = plus;
+                    if (minus.HasValues) diff["actual"] = minus;
                 }
                     break;
                 default:

--- a/src/Bard/Internal/Then/BardSnapshot.cs
+++ b/src/Bard/Internal/Then/BardSnapshot.cs
@@ -47,7 +47,7 @@ namespace Bard.Internal.Then
             var snapShooter = SnapShooter;
             var snapshotFullName = snapShooter.ResolveSnapshotFullName(snapshotNameExtension: snapshotExtension);
             _logWriter.LogMessage("");
-            _logWriter.LogMessage($"MATCHING AGAINST SNAPSHOT: '{snapshotFullName.Filename}'");
+            _logWriter.LogMessage($"MATCHING AGAINST SNAPSHOT: {snapshotFullName.FolderPath}\\{snapshotFullName.Filename}");
             snapShooter.AssertSnapshot(content, snapshotFullName, matchOptions);
         }
     }

--- a/src/Bard/Internal/Then/PerformanceMonitor.cs
+++ b/src/Bard/Internal/Then/PerformanceMonitor.cs
@@ -1,0 +1,55 @@
+using System;
+using Bard.Infrastructure;
+using Bard.Internal.When;
+
+namespace Bard.Internal.Then
+{
+    internal class PerformanceMonitor
+    {
+        private readonly LogWriter _logWriter;
+
+        public PerformanceMonitor(LogWriter logWriter)
+        {
+            _logWriter = logWriter;
+        }
+
+        public void AssertElapsedTime(Func<IResponse>? apiRequest, ApiResult apiResult, int? maxElapsedTime)
+        {
+            const int retryCount = 3;
+            IResponse RetryApiCall(int i)
+            {
+                var response = apiRequest();
+                
+                _logWriter.LogMessage($"Retry #{i + 1} Response Time: {response.ElapsedTime?.TotalMilliseconds} (milliseconds)");
+                _logWriter.BlankLine();
+                _logWriter.LogLineBreak();
+                _logWriter.BlankLine();
+                return response;
+
+            }
+
+            if (apiResult.ExceededElapsedTime(maxElapsedTime))
+            {
+                if (apiRequest == null) return;
+                
+                _logWriter.LogHeaderMessage($"The API response took longer than {maxElapsedTime} milliseconds. ({apiResult.ElapsedTime?.TotalMilliseconds})");
+                
+                var totalTime = new TimeSpan();
+                
+                for (var i = 0 ;i < retryCount; i++)
+                {
+                    var response = RetryApiCall(i);
+
+                    totalTime = totalTime.Add(response.ElapsedTime.GetValueOrDefault());
+                }
+
+                var averageTime = totalTime.Divide(retryCount);
+                
+                _logWriter.LogMessage($"Average Response Time: {averageTime.TotalMilliseconds} (milliseconds)");
+                
+                apiResult.AssertElapsedTime(averageTime, maxElapsedTime);
+                
+            }
+        }
+    }
+}

--- a/src/Bard/Internal/When/Api.cs
+++ b/src/Bard/Internal/When/Api.cs
@@ -46,9 +46,9 @@ namespace Bard.Internal.When
             var messageContent = CreateMessageContent(model);
             var responseMessage = AsyncHelper.RunSync(() => _httpClient.PatchAsync(route, messageContent));
 
-            var responseString = AsyncHelper.RunSync(() => responseMessage.Content.ReadAsStringAsync());
-            var apiResult = new ApiResult(responseMessage, responseString);
-            var response = new Response(_eventAggregator, apiResult, _badRequestProvider, _logWriter);
+            AsyncHelper.RunSync(() => responseMessage.Content.ReadAsStringAsync());
+            
+            var response = new Response(_eventAggregator,  _httpClient.Result, _badRequestProvider, _logWriter);
 
             return response;
         }
@@ -70,9 +70,9 @@ namespace Bard.Internal.When
         public IResponse Get(string route)
         {
             var message = AsyncHelper.RunSync(() => _httpClient.GetAsync(route));
-            var content = AsyncHelper.RunSync(() => message.Content.ReadAsStringAsync());
-            var apiResult = new ApiResult(message, content);
-            var response = new Response(_eventAggregator, apiResult, _badRequestProvider, _logWriter);
+            AsyncHelper.RunSync(() => message.Content.ReadAsStringAsync());
+            
+            var response = new Response(_eventAggregator,  _httpClient.Result, _badRequestProvider, _logWriter);
 
             return response;
         }
@@ -81,9 +81,9 @@ namespace Bard.Internal.When
         {
             var message = AsyncHelper.RunSync(() => _httpClient.DeleteAsync(route));
 
-            var content = AsyncHelper.RunSync(() => message.Content.ReadAsStringAsync());
-            var apiResult = new ApiResult(message, content);
-            var response = new Response(_eventAggregator, apiResult, _badRequestProvider, _logWriter);
+            AsyncHelper.RunSync(() => message.Content.ReadAsStringAsync());
+    
+            var response = new Response(_eventAggregator,  _httpClient.Result, _badRequestProvider, _logWriter);
 
             return response;
         }
@@ -100,27 +100,25 @@ namespace Bard.Internal.When
             return new StringContent(json, Encoding.UTF8, "application/json");
         }
 
-        private IResponse PostOrPut(Func<HttpClient, StringContent, Task<HttpResponseMessage>> callHttpClient)
+        private IResponse PostOrPut(Func<BardHttpClient, StringContent, Task<HttpResponseMessage>> callHttpClient)
         {
             var messageContent = CreateMessageContent(null);
 
-            var responseMessage = AsyncHelper.RunSync(() => callHttpClient(_httpClient, messageContent));
+            AsyncHelper.RunSync(() => callHttpClient(_httpClient, messageContent));
+           
+            var response = new Response(_eventAggregator,  _httpClient.Result, _badRequestProvider, _logWriter);
 
-            var responseString = AsyncHelper.RunSync(() => responseMessage.Content.ReadAsStringAsync());
-            var apiResult = new ApiResult(responseMessage, responseString);
-            var response = new Response(_eventAggregator, apiResult, _badRequestProvider, _logWriter);
             return response;
         }
 
         private IResponse PostOrPut<TModel>(TModel model,
-            Func<HttpClient, StringContent, Task<HttpResponseMessage>> callHttpClient)
+            Func<BardHttpClient, StringContent, Task<HttpResponseMessage>> callHttpClient)
         {
             var messageContent = CreateMessageContent(model);
-            var responseMessage = AsyncHelper.RunSync(() => callHttpClient(_httpClient, messageContent));
+            AsyncHelper.RunSync(() => callHttpClient(_httpClient, messageContent));
 
-            var responseString = AsyncHelper.RunSync(() => responseMessage.Content.ReadAsStringAsync());
-            var apiResult = new ApiResult(responseMessage, responseString);
-            var response = new Response(_eventAggregator, apiResult, _badRequestProvider, _logWriter);
+            var response = new Response(_eventAggregator, _httpClient.Result, _badRequestProvider, _logWriter);
+            
             return response;
         }
     }

--- a/src/Bard/Internal/When/ApiResult.cs
+++ b/src/Bard/Internal/When/ApiResult.cs
@@ -17,11 +17,21 @@ namespace Bard.Internal.When
         public HttpResponseMessage ResponseMessage { get; }
         public string ResponseString { get; }
 
+        public void AssertElapsedTime(TimeSpan? elapsedTime, int? milliseconds)
+        {
+            if (ExceededElapsedTime(milliseconds))
+                throw new BardException(
+                    $"The API response took longer than {milliseconds} milliseconds. ({elapsedTime?.TotalMilliseconds})");
+        }
+        
         public void AssertElapsedTime(int? milliseconds)
         {
-            if (milliseconds.HasValue && ElapsedTime != null && ElapsedTime.Value.TotalMilliseconds > milliseconds)
-                throw new BardException(
-                    $"The API response took longer than {milliseconds} milliseconds. ({ElapsedTime.Value.TotalMilliseconds})");
+            AssertElapsedTime(ElapsedTime, milliseconds);
+        }
+
+        public bool ExceededElapsedTime(int? milliseconds)
+        {
+            return milliseconds.HasValue && ElapsedTime != null && ElapsedTime.Value.TotalMilliseconds > milliseconds;
         }
     }
 }

--- a/src/Bard/Internal/When/BardApiMessageHandler.cs
+++ b/src/Bard/Internal/When/BardApiMessageHandler.cs
@@ -25,24 +25,24 @@ namespace Bard.Internal.When
     internal class BardResponsePublisher : DelegatingHandler
     {
         public Action<ApiResult>? PublishApiResult;
-        public Stopwatch Stopwatch;
+        private readonly Stopwatch _stopwatch;
 
         public BardResponsePublisher(HttpMessageHandler innerHandler) : base(innerHandler)
         {
-            Stopwatch = new Stopwatch();
+            _stopwatch = new Stopwatch();
         }
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
-            Stopwatch.Reset();
-            Stopwatch.Start();
+            _stopwatch.Reset();
+            _stopwatch.Start();
             
             var response = await base.SendAsync(request, cancellationToken);
             
-            Stopwatch.Stop();
+            _stopwatch.Stop();
             var responseString = await response.Content.ReadAsStringAsync();
-            var apiResult = new ApiResult(response, responseString, Stopwatch.Elapsed);
+            var apiResult = new ApiResult(response, responseString, _stopwatch.Elapsed);
 
             PublishApiResult?.Invoke(apiResult);
 

--- a/src/Bard/Internal/When/BardApiMessageHandler.cs
+++ b/src/Bard/Internal/When/BardApiMessageHandler.cs
@@ -6,22 +6,6 @@ using System.Threading.Tasks;
 
 namespace Bard.Internal.When
 {
-    internal class GrpcMessageHandler : DelegatingHandler
-    {
-        public GrpcMessageHandler(HttpMessageHandler innerHandler) : base(innerHandler)
-        {
-        }
-
-        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            var response = await base.SendAsync(request, cancellationToken);
-            
-            response.Version = request.Version;
-
-            return response;
-        }
-    }
-
     internal class BardResponsePublisher : DelegatingHandler
     {
         public Action<ApiResult>? PublishApiResult;

--- a/src/Bard/Internal/When/GrpcMessageHandler.cs
+++ b/src/Bard/Internal/When/GrpcMessageHandler.cs
@@ -1,0 +1,22 @@
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Bard.Internal.When
+{
+    internal class GrpcMessageHandler : DelegatingHandler
+    {
+        public GrpcMessageHandler(HttpMessageHandler innerHandler) : base(innerHandler)
+        {
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = await base.SendAsync(request, cancellationToken);
+            
+            response.Version = request.Version;
+
+            return response;
+        }
+    }
+}

--- a/src/Bard/Internal/When/When.cs
+++ b/src/Bard/Internal/When/When.cs
@@ -10,19 +10,22 @@ namespace Bard.Internal.When
     internal class When : IWhen
     {
         private readonly Api _api;
+        private readonly EventAggregator _eventAggregator;
         private readonly LogWriter _logWriter;
         protected readonly Action? PreApiCall;
 
-        internal When(Api api, LogWriter logWriter)
+        internal When(Api api, EventAggregator eventAggregator, LogWriter logWriter)
         {
             _api = api;
+            _eventAggregator = eventAggregator;
             _logWriter = logWriter;
         }
         
-        internal When(Api api, LogWriter logWriter,
+        internal When(Api api, EventAggregator eventAggregator, LogWriter logWriter,
             Action preApiCall)
         {
             _api = api;
+            _eventAggregator = eventAggregator;
             _logWriter = logWriter;
             PreApiCall = preApiCall;
         }
@@ -74,7 +77,9 @@ namespace Bard.Internal.When
             WriteHeader();
             
             var response = callApi();
-
+            
+            _eventAggregator.PublishApiRequest(callApi);
+            
             return response;
         }
 


### PR DESCRIPTION
Add performance monitor.
Now when a performance tests fails...the api request will be rerun a configured number of times and the average taken.