### PR TITLE
Grpc tests

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: dotnet restore src
     - name: Build
-      run: dotnet build src --configuration Release --no-restore  -p:ParallelizeTestCollections=false
+      run: dotnet build src --configuration Release --no-restore
     - name: Publish Bard
       uses: brandedoutcast/publish-nuget@v2.5.2
       with:

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: dotnet restore src
     - name: Build
-      run: dotnet build src --configuration Release --no-restore  
+      run: dotnet build src --configuration Release --no-restore  -p:ParallelizeTestCollections=false
     - name: Publish Bard
       uses: brandedoutcast/publish-nuget@v2.5.2
       with:

--- a/src/Bard.Tests/Bard.Tests.csproj
+++ b/src/Bard.Tests/Bard.Tests.csproj
@@ -35,4 +35,10 @@
       <ProjectReference Include="..\Sample.Api\Sample.Api.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <None Update="xunit.runner.json">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
+    </ItemGroup>
+
 </Project>

--- a/src/Bard.Tests/gRPC/GRpcExtensionMethodTests.cs
+++ b/src/Bard.Tests/gRPC/GRpcExtensionMethodTests.cs
@@ -34,7 +34,7 @@ namespace Bard.Tests.gRPC
             _httpClient = testClient;
         }
         
-        [Fact(Skip = "skipping for now")]
+        [Fact]
         public void Call_grpc_with_story_book()
         {
             GrpcChannelOptions channelOptions = new GrpcChannelOptions

--- a/src/Bard.Tests/gRPC/RetrievingABankAccount.cs
+++ b/src/Bard.Tests/gRPC/RetrievingABankAccount.cs
@@ -53,7 +53,7 @@ namespace Bard.Tests.gRPC
         {
         }
 
-        [Fact(Skip = "skipping for now")]
+        [Fact]
         public void Foo()
         {
             Scenario

--- a/src/Bard.Tests/gRPC/gRPCTests.cs
+++ b/src/Bard.Tests/gRPC/gRPCTests.cs
@@ -33,7 +33,7 @@ namespace Bard.Tests.gRPC
         private readonly HttpClient _httpClient;
         private readonly IHost _host;
 
-        [Fact(Skip = "skipping for now")]
+        [Fact]
         public void Call_grpc_with_story_book()
         {
             var scenario = GrpcScenarioConfiguration
@@ -61,7 +61,7 @@ namespace Bard.Tests.gRPC
             scenario.Then.Response.ShouldBe.Ok();
         }
 
-        [Fact(Skip = "skipping for now")]
+        [Fact]
         public void Call_grpc_without_story_book()
         {
             var scenario = GrpcScenarioConfiguration
@@ -81,7 +81,7 @@ namespace Bard.Tests.gRPC
             scenario.Then.Response.ShouldBe.Ok();
         }
         
-        [Fact(Skip = "skipping for now")]
+        [Fact]
         public void Call_grpc_snapshot()
         {
             var scenario = GrpcScenarioConfiguration
@@ -103,7 +103,7 @@ namespace Bard.Tests.gRPC
             scenario.Then.Snapshot().Match<CreditReply>();
         }
         
-        [Fact(Skip = "skipping for now")]
+        [Fact]
         public void Call_new_grpc_with_story_book()
         {
             var scenario = GrpcScenarioConfiguration

--- a/src/Bard.Tests/xunit.runner.json
+++ b/src/Bard.Tests/xunit.runner.json
@@ -1,0 +1,4 @@
+﻿{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "parallelizeTestCollections": false
+}


### PR DESCRIPTION
- Re-enables grpc tests
- Disables parallel tests, this makes the grpc tests.

The parallel testing doesn't work as it reuses channels.