### PR TITLE
feat: add send api method so that entire request message configured

### DIFF
--- a/src/Bard/IApi.cs
+++ b/src/Bard/IApi.cs
@@ -80,5 +80,12 @@ namespace Bard
         /// <param name="requestSetup">configure outgoing http request (optional)</param>
         /// <returns>IResponse</returns>
         IResponse Patch<TModel>(string route, TModel model, Action<HttpRequestMessage>? requestSetup = null);
+
+        /// <summary>
+        ///     Send a request
+        /// </summary>
+        /// <param name="requestSetup">configure outgoing http request</param>
+        /// <returns>IResponse</returns>
+        IResponse Send(Action<HttpRequestMessage> requestSetup);
     }
 }

--- a/src/Bard/Internal/When/Api.cs
+++ b/src/Bard/Internal/When/Api.cs
@@ -135,6 +135,24 @@ namespace Bard.Internal.When
             return response;
         }
 
+        
+        public IResponse Send(Action<HttpRequestMessage> requestSetup)
+        {
+            var message = AsyncHelper.RunSync(() =>
+            {
+                var httpRequestMessage = new HttpRequestMessage();
+                requestSetup(httpRequestMessage);
+
+                return _httpClient.SendAsync(httpRequestMessage);
+            });
+
+            AsyncHelper.RunSync(() => message.Content.ReadAsStringAsync());
+
+            var response = new Response(_eventAggregator, _httpClient.Result, _badRequestProvider, _logWriter);
+
+            return response;
+        }
+
         private StringContent CreateMessageContent(object? message)
         {
             var json = message == null

--- a/src/Bard/Internal/When/When.cs
+++ b/src/Bard/Internal/When/When.cs
@@ -72,6 +72,11 @@ namespace Bard.Internal.When
             return CallApi(() => _api.Get(route, requestSetup));
         }
 
+        public IResponse Send(Action<HttpRequestMessage> requestSetup)
+        {
+            return CallApi(() => _api.Send(requestSetup));
+        }
+
         private IResponse CallApi(Func<IResponse> callApi)
         {
             PreApiCall?.Invoke();


### PR DESCRIPTION
Add a `Send` implementation to `IApi`.

In my test setup, I have an extension method that builds the `HttpRequestMethod` using expressions. This removes the hardcoded routes from the tests and compile-time errors when action parameters change.

e.g. 

```
scenario.When
    .Send(r => r.CreateRequest<ValuesController>(c => c.Post(new PostValues { Data = "payload" })));
```

for 

```
[HttpPost]
public async Task<IActionResult> Post([FromBody] PostValues values)
{
    await Task.CompletedTask;
    return Ok();
}
```